### PR TITLE
Fix missing NUL terminator in header size field.

### DIFF
--- a/src/tar.toit
+++ b/src/tar.toit
@@ -80,7 +80,7 @@ class Header:
     write-octal_ bytes_ PERMISSIONS-OFFSET_ (PERMISSIONS-LENGTH_ - 1) permissions
     write-octal_ bytes_ UID-OFFSET_ (UID-LENGTH_ - 1) uid
     write-octal_ bytes_ GID-OFFSET_ (GID-LENGTH_ - 1) gid
-    write-octal_ bytes_ SIZE-OFFSET_ SIZE-LENGTH_ size
+    write-octal_ bytes_ SIZE-OFFSET_ (SIZE-LENGTH_ - 1) size
     mtime-val := mtime.ms-since-epoch / 1000
     write-octal_ bytes_ MTIME-OFFSET_ (MTIME-LENGTH_ - 1) mtime-val
     // The checksum is computed using spaces. Later it is replaced with the actual values.

--- a/tests/properties-test.toit
+++ b/tests/properties-test.toit
@@ -74,6 +74,8 @@ test-properties:
   expect-equals 1000 (parse-octal.call 108 8)
   expect-equals 1000 (parse-octal.call 116 8)
   expect-equals 7 (parse-octal.call 124 12) // "content".size = 7
+  // The last byte of the size field must be a NUL terminator.
+  expect-equals 0 header[124 + 12 - 1]
   expect-equals 1234567890 (parse-octal.call 136 12)
   expect-equals tar.TYPE-REGULAR-FILE header[156]
   expect-equals "ustar  " (parse-string.call 257 8)

--- a/tests/reader-test.toit
+++ b/tests/reader-test.toit
@@ -14,6 +14,7 @@ main:
   test-multiple-files
   test-long-name
   test-properties
+  test-size-nul-terminator
 
 /**
 Helper that writes a tar archive to a buffer and returns the bytes.
@@ -139,5 +140,23 @@ test-properties:
     expect-equals "group" header.group-name
     expect-equals 1 header.device-major
     expect-equals 2 header.device-minor
+    expect-equals "content" content.to-string
+  expect-equals 1 count
+
+test-size-nul-terminator:
+  bytes := write-tar: |tw/tar.Writer|
+    tw.add "file.txt" "content"
+
+  // Verify the size field's last byte is a NUL terminator.
+  // The size field is at offset 124 with length 12.
+  expect-equals 0 bytes[124 + 12 - 1]
+
+  // Roundtrip: the Reader must parse the size correctly.
+  reader := tar.Reader (io.Reader bytes)
+  count := 0
+  reader.do: |header/tar.Header content/ByteArray|
+    count++
+    expect-equals "file.txt" header.name
+    expect-equals 7 header.size
     expect-equals "content" content.to-string
   expect-equals 1 count


### PR DESCRIPTION
The size field was written using the full SIZE-LENGTH_ (12) instead of SIZE-LENGTH_ - 1, filling all 12 bytes with octal digits and leaving no room for a NUL terminator. This caused C parsers using strtol to read past the size field into the adjacent mtime field.